### PR TITLE
bug

### DIFF
--- a/slidePage.js
+++ b/slidePage.js
@@ -47,6 +47,8 @@
                 urlObject[item[0]] = item[1];
             }
             return urlObject;
+        }else{
+            return urlObject.page = 1;
         }
     }
     function swipeUp(event) {


### PR DESCRIPTION
当链接不加?page=1时会报错，修复了这个问题；
不知道作者是否有意为之，作为使用者，使用中不加参数的情况还是挺多的。
